### PR TITLE
Pull request: first bug fix - unbalanced curly braces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+config_parser
+config_parser_test
+gtest-all.o
+libgtest.a

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -152,6 +152,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
   config_stack.push(config);
   TokenType last_token_type = TOKEN_TYPE_START;
   TokenType token_type;
+  int unmatched_parens = 0;
   while (true) {
     std::string token;
     token_type = ParseToken(config_file, &token);
@@ -190,6 +191,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         break;
       }
     } else if (token_type == TOKEN_TYPE_START_BLOCK) {
+      unmatched_parens++;
       if (last_token_type != TOKEN_TYPE_NORMAL) {
         // Error.
         break;
@@ -199,12 +201,18 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
+      if(--unmatched_parens < 0) {
+        break;
+      }
       if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
         // Error.
         break;
       }
       config_stack.pop();
     } else if (token_type == TOKEN_TYPE_EOF) {
+      if(unmatched_parens) {
+        break;
+      }
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
           last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -201,20 +201,14 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
-      if(--unmatched_parens < 0) {
-        break;
-      }
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
+      if (--unmatched_parens < 0 || last_token_type != TOKEN_TYPE_STATEMENT_END) {
         // Error.
         break;
       }
       config_stack.pop();
     } else if (token_type == TOKEN_TYPE_EOF) {
-      if(unmatched_parens) {
-        break;
-      }
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
-          last_token_type != TOKEN_TYPE_END_BLOCK) {
+      if (unmatched_parens || (last_token_type != TOKEN_TYPE_STATEMENT_END &&
+          last_token_type != TOKEN_TYPE_END_BLOCK)) {
         // Error.
         break;
       }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -9,3 +9,37 @@ TEST(NginxConfigParserTest, SimpleConfig) {
 
   EXPECT_TRUE(success);
 }
+
+TEST(NginxConfigParserTest, ToStringTest) {
+	NginxConfigStatement statement;
+	statement.tokens_.push_back("listen");
+	statement.tokens_.push_back("80");
+	EXPECT_EQ(statement.ToString(0), "listen 80;\n");
+}
+
+class NginxConfigStringTest : public ::testing::Test {
+protected:
+	bool ParseString(const std::string config_string) {
+		std::stringstream config_stream(config_string);
+		return parser.Parse(&config_stream, &out_config);
+	}
+	NginxConfigParser parser;
+	NginxConfig out_config;
+};
+
+TEST_F(NginxConfigStringTest, EmptyConfigTest) {
+	EXPECT_FALSE(ParseString(""));
+}
+
+TEST_F(NginxConfigStringTest, EmptyInsideTest) {
+	EXPECT_FALSE(ParseString("server { }"));
+}
+
+TEST_F(NginxConfigStringTest, MissingSemiColonTest) {
+	EXPECT_FALSE(ParseString("server { listen 80 }"));
+}
+
+TEST_F(NginxConfigStringTest, UnbalancedCurlyBraces) {
+	EXPECT_FALSE(ParseString("server { "));
+	EXPECT_FALSE(ParseString("server { listen 80;"));
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -42,4 +42,5 @@ TEST_F(NginxConfigStringTest, MissingSemiColonTest) {
 TEST_F(NginxConfigStringTest, UnbalancedCurlyBraces) {
 	EXPECT_FALSE(ParseString("server { "));
 	EXPECT_FALSE(ParseString("server { listen 80;"));
+	EXPECT_FALSE(ParseString("server listen 80; }"));
 }


### PR DESCRIPTION
Fix entails keeping an int variable "unmatched_parens" which is incremented and decremented as TOKEN_TYPE_START_BLOCK and TOKEN_TYPE_END_BLOCK are encountered respectively. Errors occur when the variable is not equal to zero at the end of parse or less than zero at any point.